### PR TITLE
Add PyQt6 learning app framework with AI integration

### DIFF
--- a/ai_interface.py
+++ b/ai_interface.py
@@ -1,0 +1,120 @@
+"""Async wrapper around Google Gemini with graceful fallbacks."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Dict, List
+
+import httpx
+
+from content_generator import (
+    answer_question_locally,
+    generate_local_exercises,
+    generate_local_lesson,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-pro")
+GEMINI_ENDPOINT = os.getenv(
+    "GEMINI_API_ENDPOINT",
+    f"https://generativelanguage.googleapis.com/v1beta/models/{GEMINI_MODEL}:generateContent",
+)
+TIMEOUT = 30.0
+
+
+async def _request_from_gemini(prompt: str) -> str:
+    if not GEMINI_API_KEY:
+        raise RuntimeError("GEMINI_API_KEY is not set.")
+
+    payload = {"contents": [{"parts": [{"text": prompt}]}]}
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        response = await client.post(
+            GEMINI_ENDPOINT,
+            params={"key": GEMINI_API_KEY},
+            json=payload,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+    candidates = data.get("candidates") or []
+    for candidate in candidates:
+        parts = candidate.get("content", {}).get("parts", [])
+        for part in parts:
+            text = part.get("text")
+            if text:
+                return text
+    raise RuntimeError("Gemini response did not include any text.")
+
+
+async def generate_lesson(subject: str, grade: int, topic: str) -> str:
+    prompt = (
+        "You are a friendly elementary school teacher. "
+        f"Create a concise lesson for grade {grade} {subject} learners about {topic}. "
+        "Use inviting language, short paragraphs, and include one practical activity suggestion."
+    )
+    try:
+        lesson_text = await _request_from_gemini(prompt)
+        return lesson_text.strip()
+    except Exception as exc:  # pragma: no cover - best effort logging
+        LOGGER.warning("Falling back to local lesson for %s grade %s: %s", subject, grade, exc)
+        return generate_local_lesson(subject, grade, topic)
+
+
+async def generate_exercises(subject: str, grade: int, topic: str) -> List[Dict[str, str]]:
+    prompt = (
+        "Create three short practice questions for grade {grade} students in {subject} about {topic}. "
+        "Respond with a JSON list where each item has keys 'question', 'expected_answer', and 'hint'."
+    ).format(grade=grade, subject=subject, topic=topic)
+    try:
+        response_text = await _request_from_gemini(prompt)
+        exercises = json.loads(response_text)
+        if not isinstance(exercises, list):
+            raise ValueError("Gemini exercise response must be a list")
+        parsed: List[Dict[str, str]] = []
+        for exercise in exercises:
+            if not isinstance(exercise, dict):
+                raise ValueError("Exercise entry must be a dict")
+            question = str(exercise.get("question", "")).strip()
+            answer = str(exercise.get("expected_answer", "")).strip()
+            hint = str(exercise.get("hint", "Use clues from the lesson."))
+            if question:
+                parsed.append({"question": question, "expected_answer": answer, "hint": hint})
+        if parsed:
+            return parsed
+        raise ValueError("No valid exercises returned")
+    except Exception as exc:  # pragma: no cover - best effort logging
+        LOGGER.warning("Falling back to local exercises for %s grade %s: %s", subject, grade, exc)
+        return generate_local_exercises(subject, grade, topic)
+
+
+async def answer_question(question: str, lesson_context: str, student_answer: str) -> str:
+    prompt = (
+        "You are an encouraging tutor. A student answered a question incorrectly. "
+        "Provide gentle feedback using the lesson summary and student response.\n"
+        f"Lesson summary: {lesson_context}\n"
+        f"Question: {question}\n"
+        f"Student answer: {student_answer}\n"
+        "Respond with two short sentences offering guidance."
+    )
+    try:
+        return (await _request_from_gemini(prompt)).strip()
+    except Exception as exc:  # pragma: no cover - best effort logging
+        LOGGER.warning("Falling back to local answer helper: %s", exc)
+        return answer_question_locally(question, lesson_context)
+
+
+def generate_lesson_sync(subject: str, grade: int, topic: str) -> str:
+    return asyncio.run(generate_lesson(subject, grade, topic))
+
+
+def generate_exercises_sync(subject: str, grade: int, topic: str) -> List[Dict[str, str]]:
+    return asyncio.run(generate_exercises(subject, grade, topic))
+
+
+def answer_question_sync(question: str, lesson_context: str, student_answer: str) -> str:
+    return asyncio.run(answer_question(question, lesson_context, student_answer))

--- a/content_generator.py
+++ b/content_generator.py
@@ -1,0 +1,153 @@
+"""Local content generator used as a deterministic fallback when the AI service
+is not available."""
+
+from __future__ import annotations
+
+import random
+from typing import Dict, List, Tuple
+
+# Seed the random number generator to keep exercise order consistent between
+# runs.  This makes behaviour more predictable for tests while still providing
+# some variety when the module is expanded in the future.
+random.seed(1234)
+
+
+LOCAL_CONTENT: Dict[str, Dict[int, Dict[str, Dict[str, str]]]] = {
+    "Mathematics": {
+        3: {
+            "Fractions": {
+                "lesson": (
+                    "Fractions represent equal parts of a whole. When we write "
+                    "a fraction like 1/2, the number on top (the numerator) "
+                    "tells us how many parts we have and the number on the bottom "
+                    "(the denominator) tells us how many equal parts the whole is "
+                    "divided into."
+                ),
+                "concept": "Understanding halves, thirds, and quarters of shapes and groups.",
+            },
+            "Multiplication": {
+                "lesson": (
+                    "Multiplication is repeated addition. To find 3 × 4, add 4 "
+                    "three times (4 + 4 + 4 = 12). Arrays and equal groups help "
+                    "us visualise multiplication problems."
+                ),
+                "concept": "Building fluency with times tables up to 5.",
+            },
+        },
+        4: {
+            "Decimals": {
+                "lesson": (
+                    "Decimals are another way to write fractions. 0.5 is the same "
+                    "as 1/2 because it represents 5 tenths. Each place to the "
+                    "right of the decimal point is worth ten times less than the "
+                    "place before it."
+                ),
+                "concept": "Linking tenths and hundredths to place value charts.",
+            }
+        },
+    },
+    "Science": {
+        3: {
+            "Life Cycles": {
+                "lesson": (
+                    "Plants and animals go through life cycles. A butterfly starts "
+                    "as an egg, becomes a caterpillar, forms a chrysalis, and "
+                    "emerges as an adult butterfly. Each stage has a special job."
+                ),
+                "concept": "Recognising patterns in living things.",
+            }
+        },
+        4: {
+            "Energy": {
+                "lesson": (
+                    "Energy is the ability to do work. It can take many forms "
+                    "such as light, heat, and movement. Energy can change from "
+                    "one form to another, like when electricity powers a lamp."
+                ),
+                "concept": "Observing energy transfers in everyday situations.",
+            }
+        },
+    },
+}
+
+
+def get_available_grades() -> List[int]:
+    grades = set()
+    for subject in LOCAL_CONTENT.values():
+        grades.update(subject.keys())
+    return sorted(grades)
+
+
+def get_subjects_for_grade(grade: int) -> List[str]:
+    return sorted(
+        subject
+        for subject, grade_data in LOCAL_CONTENT.items()
+        if grade in grade_data
+    )
+
+
+def get_topics(subject: str, grade: int) -> List[str]:
+    subject_data = LOCAL_CONTENT.get(subject, {})
+    return sorted(subject_data.get(grade, {}).keys())
+
+
+def _select_content(subject: str, grade: int, topic: str) -> Dict[str, str]:
+    subject_data = LOCAL_CONTENT.get(subject, {})
+    grade_data = subject_data.get(grade, {})
+    content = grade_data.get(topic)
+    if not content:
+        raise KeyError(f"No local content for {subject} grade {grade} topic {topic}.")
+    return content
+
+
+def generate_local_lesson(subject: str, grade: int, topic: str) -> str:
+    content = _select_content(subject, grade, topic)
+    return (
+        f"Lesson Topic: {topic}\n"
+        f"Grade Level: {grade}\n"
+        f"Subject: {subject}\n\n"
+        f"Big Idea: {content['concept']}\n\n"
+        f"Key Learning:\n{content['lesson']}\n\n"
+        "Try sketching or acting out the idea to help it stick!"
+    )
+
+
+def generate_local_exercises(subject: str, grade: int, topic: str) -> List[Dict[str, str]]:
+    content = _select_content(subject, grade, topic)
+    concept = content["concept"]
+    base_questions: List[Tuple[str, str]] = [
+        (f"Explain the main idea of {topic.lower()} in your own words.", concept),
+        (f"Give a real-life example related to {topic.lower()}.", concept),
+    ]
+
+    if subject == "Mathematics" and "fraction" in topic.lower():
+        base_questions.append(("What fraction of a pizza is left if you eat 3 of 8 slices?", "5/8"))
+    elif subject == "Mathematics" and "multiplication" in topic.lower():
+        base_questions.append(("Solve 4 × 6.", "24"))
+    elif subject == "Science" and "energy" in topic.lower():
+        base_questions.append(("Name two forms of energy you use at school.", "light and sound"))
+
+    random.shuffle(base_questions)
+    return [
+        {
+            "question": question,
+            "expected_answer": answer,
+            "hint": f"Think about: {concept}",
+        }
+        for question, answer in base_questions
+    ]
+
+
+def answer_question_locally(question: str, context: str) -> str:
+    question_lower = question.lower()
+    if "fraction" in question_lower and "pizza" in question_lower:
+        return "If 3 of 8 slices are eaten, 5/8 of the pizza remains."
+    if "4 × 6" in question or "4 x 6" in question_lower:
+        return "4 × 6 equals 24."
+    if "energy" in question_lower:
+        return "Common forms include light, sound, and heat energy."
+
+    return (
+        "Think back to the main idea of the lesson. Highlight key words in the "
+        "question and match them to details from the lesson text."
+    )

--- a/data_store.py
+++ b/data_store.py
@@ -1,0 +1,59 @@
+"""Utilities for persisting student progress to disk."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, asdict
+from typing import Any, Dict
+
+
+DEFAULT_DATA_DIR = "data"
+
+
+@dataclass
+class StudentProgress:
+    """Simple structure describing the student's progress."""
+
+    student_id: str
+    completed_lessons: list
+    completed_tests: list
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any], student_id: str) -> "StudentProgress":
+        return cls(
+            student_id=student_id,
+            completed_lessons=payload.get("completed_lessons", []),
+            completed_tests=payload.get("completed_tests", []),
+        )
+
+
+def _progress_path(student_id: str, data_dir: str = DEFAULT_DATA_DIR) -> str:
+    os.makedirs(data_dir, exist_ok=True)
+    safe_id = student_id.replace(os.sep, "_")
+    return os.path.join(data_dir, f"{safe_id}.json")
+
+
+def save_progress(progress: StudentProgress, data_dir: str = DEFAULT_DATA_DIR) -> None:
+    """Persist ``progress`` to disk in a JSON file."""
+
+    path = _progress_path(progress.student_id, data_dir=data_dir)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(asdict(progress), handle, indent=2, sort_keys=True)
+
+
+def load_progress(student_id: str, data_dir: str = DEFAULT_DATA_DIR) -> StudentProgress:
+    """Load progress for ``student_id`` from disk.
+
+    If the student has no stored progress yet this will return an empty
+    :class:`StudentProgress` instance.
+    """
+
+    path = _progress_path(student_id, data_dir=data_dir)
+    if not os.path.exists(path):
+        return StudentProgress(student_id=student_id, completed_lessons=[], completed_tests=[])
+
+    with open(path, "r", encoding="utf-8") as handle:
+        payload: Dict[str, Any] = json.load(handle)
+
+    return StudentProgress.from_dict(payload, student_id=student_id)

--- a/games/__init__.py
+++ b/games/__init__.py
@@ -1,0 +1,1 @@
+"""Mini-games included with the Luca learning environment."""

--- a/games/labyrinth_game.py
+++ b/games/labyrinth_game.py
@@ -1,0 +1,169 @@
+"""Simple labyrinth mini-game built with pygame.
+
+This module is intentionally lightweight: the maze is generated using a fixed
+layout so that the game starts instantly.  The :func:`run_labyrinth_game`
+function is imported by :mod:`main` and can be wired to a button in the UI.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import List, Tuple
+
+try:
+    import pygame
+except Exception as exc:  # pragma: no cover - pygame might not be installed
+    pygame = None
+    _IMPORT_ERROR = exc
+else:
+    _IMPORT_ERROR = None
+
+CELL_SIZE = 48
+GRID = [
+    "####################",
+    "#S   #         #   #",
+    "### ### #### # # # #",
+    "#     #    # # # # #",
+    "# ### #### # # # # #",
+    "# #   #    #   #   #",
+    "# # ### ####### ###E",
+    "# #   #       #   ##",
+    "# ### # ##### ###  #",
+    "#     #     #     ##",
+    "####################",
+]
+ROWS = len(GRID)
+COLS = len(GRID[0])
+WINDOW_SIZE = (COLS * CELL_SIZE, ROWS * CELL_SIZE)
+BG_COLOR = (30, 30, 40)
+WALL_COLOR = (70, 130, 180)
+PLAYER_COLOR = (255, 214, 10)
+EXIT_COLOR = (120, 230, 130)
+
+
+@dataclass
+class Player:
+    position: Tuple[int, int]
+
+    def move(self, dx: int, dy: int) -> None:
+        x, y = self.position
+        self.position = (x + dx, y + dy)
+
+
+def _assert_pygame_available() -> None:
+    if pygame is None:  # pragma: no cover - environment specific
+        raise RuntimeError(
+            "pygame is required to launch the labyrinth mini-game."
+        ) from _IMPORT_ERROR
+
+
+def _find_positions() -> Tuple[Tuple[int, int], Tuple[int, int]]:
+    start = exit_pos = (1, 1)
+    for row_idx, row in enumerate(GRID):
+        for col_idx, cell in enumerate(row):
+            if cell == "S":
+                start = (col_idx, row_idx)
+            elif cell == "E":
+                exit_pos = (col_idx, row_idx)
+    return start, exit_pos
+
+
+def _is_wall(col: int, row: int) -> bool:
+    if 0 <= row < ROWS and 0 <= col < COLS:
+        return GRID[row][col] == "#"
+    return True
+
+
+def _draw_grid(screen: "pygame.Surface") -> None:
+    for row_idx, row in enumerate(GRID):
+        for col_idx, cell in enumerate(row):
+            rect = pygame.Rect(col_idx * CELL_SIZE, row_idx * CELL_SIZE, CELL_SIZE, CELL_SIZE)
+            if cell == "#":
+                pygame.draw.rect(screen, WALL_COLOR, rect)
+            elif cell == "E":
+                pygame.draw.rect(screen, EXIT_COLOR, rect)
+            else:
+                pygame.draw.rect(screen, BG_COLOR, rect)
+
+
+def run_labyrinth_game() -> None:
+    """Launch the labyrinth mini-game.
+
+    The function returns when the player either reaches the exit or closes the
+    window.  In classrooms without pygame installed a helpful error is raised.
+    """
+
+    _assert_pygame_available()
+    pygame.init()
+    screen = pygame.display.set_mode(WINDOW_SIZE)
+    pygame.display.set_caption("Labyrinth Escape")
+    clock = pygame.time.Clock()
+
+    start_pos, exit_pos = _find_positions()
+    player = Player(position=start_pos)
+
+    font = pygame.font.SysFont("Arial", 24)
+    running = True
+    won = False
+
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            elif event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_ESCAPE:
+                    running = False
+                elif event.key in (pygame.K_UP, pygame.K_w):
+                    _attempt_move(player, 0, -1)
+                elif event.key in (pygame.K_DOWN, pygame.K_s):
+                    _attempt_move(player, 0, 1)
+                elif event.key in (pygame.K_LEFT, pygame.K_a):
+                    _attempt_move(player, -1, 0)
+                elif event.key in (pygame.K_RIGHT, pygame.K_d):
+                    _attempt_move(player, 1, 0)
+
+        if player.position == exit_pos:
+            won = True
+            running = False
+
+        screen.fill(BG_COLOR)
+        _draw_grid(screen)
+        _draw_player(screen, player)
+        pygame.display.flip()
+        clock.tick(30)
+
+    _show_outcome(screen, font, won)
+    pygame.time.delay(1500)
+    pygame.quit()
+
+
+def _attempt_move(player: Player, dx: int, dy: int) -> None:
+    x, y = player.position
+    new_x, new_y = x + dx, y + dy
+    if not _is_wall(new_x, new_y):
+        player.move(dx, dy)
+
+
+def _draw_player(screen: "pygame.Surface", player: Player) -> None:
+    x, y = player.position
+    rect = pygame.Rect(x * CELL_SIZE + 10, y * CELL_SIZE + 10, CELL_SIZE - 20, CELL_SIZE - 20)
+    pygame.draw.rect(screen, PLAYER_COLOR, rect, border_radius=8)
+
+
+def _show_outcome(screen: "pygame.Surface", font: "pygame.font.Font", won: bool) -> None:
+    if screen is None:
+        return
+    screen.fill(BG_COLOR)
+    message = "You escaped!" if won else "Maybe next time!"
+    text = font.render(message, True, (255, 255, 255))
+    text_rect = text.get_rect(center=(WINDOW_SIZE[0] // 2, WINDOW_SIZE[1] // 2))
+    screen.blit(text, text_rect)
+    pygame.display.flip()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual play helper
+    try:
+        run_labyrinth_game()
+    except RuntimeError as exc:  # pragma: no cover
+        sys.stderr.write(f"Failed to run labyrinth game: {exc}\n")

--- a/main.py
+++ b/main.py
@@ -1,0 +1,454 @@
+"""Entry point for the Luca learning assistant."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Dict, List, Optional
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QApplication,
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QStackedWidget,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+import ai_interface
+import content_generator
+from data_store import StudentProgress, load_progress, save_progress
+
+try:  # Optional mini-game import
+    from games.labyrinth_game import run_labyrinth_game
+except Exception:  # pragma: no cover - pygame may be missing
+    run_labyrinth_game = None
+
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+class IntroPage(QWidget):
+    started = pyqtSignal(str)
+
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QVBoxLayout(self)
+        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        title = QLabel("Welcome to Luca!")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        title.setStyleSheet("font-size: 26px; font-weight: bold;")
+
+        subtitle = QLabel("An AI-assisted learning companion.")
+        subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        subtitle.setStyleSheet("font-size: 16px;")
+
+        self.name_input = QLineEdit()
+        self.name_input.setPlaceholderText("Enter student name")
+        self.name_input.setFixedWidth(240)
+        self.name_input.setMaxLength(32)
+
+        start_button = QPushButton("Start Learning")
+        start_button.clicked.connect(self._handle_start_clicked)
+
+        layout.addWidget(title)
+        layout.addWidget(subtitle)
+        layout.addSpacing(20)
+        layout.addWidget(self.name_input, alignment=Qt.AlignmentFlag.AlignCenter)
+        layout.addSpacing(10)
+        layout.addWidget(start_button, alignment=Qt.AlignmentFlag.AlignCenter)
+
+    def _handle_start_clicked(self) -> None:
+        student_name = self.name_input.text().strip() or "student"
+        self.started.emit(student_name)
+
+
+class LessonListPage(QWidget):
+    lesson_selected = pyqtSignal(str, int, str)
+    progress_requested = pyqtSignal()
+    launch_game_requested = pyqtSignal()
+
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QVBoxLayout(self)
+
+        header = QLabel("Choose what to explore")
+        header.setStyleSheet("font-size: 22px; font-weight: bold;")
+        layout.addWidget(header)
+
+        self.grade_combo = QComboBox()
+        self.grade_combo.addItem("Select grade", userData=None)
+        for grade in content_generator.get_available_grades():
+            self.grade_combo.addItem(f"Grade {grade}", userData=grade)
+        self.grade_combo.currentIndexChanged.connect(self._update_subjects)
+
+        self.subject_combo = QComboBox()
+        self.subject_combo.addItem("Select subject", userData=None)
+        self.subject_combo.currentIndexChanged.connect(self._update_topics)
+
+        self.topic_list = QListWidget()
+
+        start_lesson_btn = QPushButton("Open Lesson")
+        start_lesson_btn.clicked.connect(self._open_selected_lesson)
+
+        progress_btn = QPushButton("View Progress")
+        progress_btn.clicked.connect(self.progress_requested.emit)
+
+        game_btn = QPushButton("Play Labyrinth Game")
+        game_btn.clicked.connect(self.launch_game_requested.emit)
+        game_btn.setEnabled(run_labyrinth_game is not None)
+
+        layout.addWidget(self.grade_combo)
+        layout.addWidget(self.subject_combo)
+        layout.addWidget(QLabel("Topics"))
+        layout.addWidget(self.topic_list)
+
+        buttons_row = QHBoxLayout()
+        buttons_row.addWidget(start_lesson_btn)
+        buttons_row.addWidget(progress_btn)
+        buttons_row.addWidget(game_btn)
+        layout.addLayout(buttons_row)
+
+    def _update_subjects(self) -> None:
+        grade = self.grade_combo.currentData()
+        self.subject_combo.blockSignals(True)
+        self.subject_combo.clear()
+        self.subject_combo.addItem("Select subject", userData=None)
+        if grade is not None:
+            for subject in content_generator.get_subjects_for_grade(grade):
+                self.subject_combo.addItem(subject, userData=subject)
+        self.subject_combo.blockSignals(False)
+        self._update_topics()
+
+    def _update_topics(self) -> None:
+        self.topic_list.clear()
+        grade = self.grade_combo.currentData()
+        subject = self.subject_combo.currentData()
+        if grade is None or subject is None:
+            return
+        for topic in content_generator.get_topics(subject, grade):
+            QListWidgetItem(topic, self.topic_list)
+
+    def _open_selected_lesson(self) -> None:
+        grade = self.grade_combo.currentData()
+        subject = self.subject_combo.currentData()
+        topic_item = self.topic_list.currentItem()
+        if grade is None or subject is None or topic_item is None:
+            QMessageBox.information(self, "Select a topic", "Please choose a grade, subject, and topic first.")
+            return
+        topic = topic_item.text()
+        self.lesson_selected.emit(subject, grade, topic)
+
+
+class LessonPage(QWidget):
+    go_back = pyqtSignal()
+    start_test = pyqtSignal()
+
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QVBoxLayout(self)
+
+        self.title_label = QLabel("Lesson")
+        self.title_label.setStyleSheet("font-size: 22px; font-weight: bold;")
+
+        self.lesson_text = QTextEdit()
+        self.lesson_text.setReadOnly(True)
+        self.lesson_text.setStyleSheet("font-size: 16px;")
+
+        button_row = QHBoxLayout()
+        back_btn = QPushButton("Back to list")
+        back_btn.clicked.connect(self.go_back.emit)
+        test_btn = QPushButton("Try quick quiz")
+        test_btn.clicked.connect(self.start_test.emit)
+
+        button_row.addWidget(back_btn)
+        button_row.addWidget(test_btn)
+
+        layout.addWidget(self.title_label)
+        layout.addWidget(self.lesson_text)
+        layout.addLayout(button_row)
+
+    def display_lesson(self, subject: str, topic: str, text: str) -> None:
+        self.title_label.setText(f"{subject} – {topic}")
+        self.lesson_text.setPlainText(text)
+
+
+class TestPage(QWidget):
+    back_requested = pyqtSignal()
+    test_completed = pyqtSignal(int, int)
+
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QVBoxLayout(self)
+
+        self.header = QLabel("Quick quiz")
+        self.header.setStyleSheet("font-size: 22px; font-weight: bold;")
+
+        self.question_label = QLabel()
+        self.question_label.setWordWrap(True)
+        self.hint_label = QLabel()
+        self.hint_label.setWordWrap(True)
+        self.hint_label.setStyleSheet("color: #666; font-style: italic;")
+
+        self.answer_input = QLineEdit()
+        self.answer_input.setPlaceholderText("Type your answer here")
+
+        self.feedback_box = QTextEdit()
+        self.feedback_box.setReadOnly(True)
+        self.feedback_box.setFixedHeight(100)
+
+        submit_btn = QPushButton("Submit answer")
+        submit_btn.clicked.connect(self._handle_submit)
+
+        next_btn = QPushButton("Next question")
+        next_btn.clicked.connect(self._handle_next)
+
+        back_btn = QPushButton("Back to lesson")
+        back_btn.clicked.connect(self.back_requested.emit)
+
+        button_row = QHBoxLayout()
+        button_row.addWidget(submit_btn)
+        button_row.addWidget(next_btn)
+        button_row.addWidget(back_btn)
+
+        layout.addWidget(self.header)
+        layout.addWidget(self.question_label)
+        layout.addWidget(self.hint_label)
+        layout.addWidget(self.answer_input)
+        layout.addWidget(self.feedback_box)
+        layout.addLayout(button_row)
+
+        self._exercises: List[Dict[str, str]] = []
+        self._index = 0
+        self._score = 0
+        self._lesson_context = ""
+
+    def load_exercises(self, exercises: List[Dict[str, str]], lesson_context: str) -> None:
+        self._exercises = exercises
+        self._index = 0
+        self._score = 0
+        self._lesson_context = lesson_context
+        self.feedback_box.clear()
+        self.answer_input.clear()
+        self._display_current_question()
+
+    def _display_current_question(self) -> None:
+        if not self._exercises:
+            self.question_label.setText("No exercises available.")
+            self.hint_label.clear()
+            return
+        exercise = self._exercises[self._index]
+        self.question_label.setText(exercise["question"])
+        self.hint_label.setText(f"Hint: {exercise.get('hint', 'Consider the lesson content.')}")
+        self.answer_input.clear()
+        self.feedback_box.clear()
+
+    def _handle_submit(self) -> None:
+        if not self._exercises:
+            return
+        exercise = self._exercises[self._index]
+        student_answer = self.answer_input.text().strip()
+        expected = exercise.get("expected_answer", "").strip()
+        correct = bool(expected) and student_answer.lower() == expected.lower()
+        if correct:
+            self.feedback_box.setPlainText("Great job! That's correct.")
+            self._score += 1
+        else:
+            feedback = ai_interface.answer_question_sync(
+                exercise["question"], self._lesson_context, student_answer
+            )
+            self.feedback_box.setPlainText(feedback)
+        self.answer_input.clear()
+
+    def _handle_next(self) -> None:
+        if not self._exercises:
+            self.back_requested.emit()
+            return
+        if self._index < len(self._exercises) - 1:
+            self._index += 1
+            self._display_current_question()
+        else:
+            total = len(self._exercises)
+            self.test_completed.emit(self._score, total)
+
+
+class ProgressPage(QWidget):
+    back_requested = pyqtSignal()
+
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QVBoxLayout(self)
+
+        header = QLabel("Progress tracker")
+        header.setStyleSheet("font-size: 22px; font-weight: bold;")
+
+        self.summary_box = QTextEdit()
+        self.summary_box.setReadOnly(True)
+
+        back_btn = QPushButton("Back")
+        back_btn.clicked.connect(self.back_requested.emit)
+
+        layout.addWidget(header)
+        layout.addWidget(self.summary_box)
+        layout.addWidget(back_btn, alignment=Qt.AlignmentFlag.AlignRight)
+
+    def display_progress(self, progress: StudentProgress) -> None:
+        lessons_lines = [
+            f"• {item['subject']} grade {item['grade']} – {item['topic']}"
+            for item in progress.completed_lessons
+        ]
+        tests_lines = [
+            f"• {item['subject']} grade {item['grade']} – {item['topic']} (score {item['score']}/{item['total']})"
+            for item in progress.completed_tests
+        ]
+        summary = [
+            f"Student: {progress.student_id}",
+            "",
+            "Completed lessons:",
+            *(lessons_lines or ["  No lessons completed yet."]),
+            "",
+            "Quiz history:",
+            *(tests_lines or ["  No quizzes taken yet."]),
+        ]
+        self.summary_box.setPlainText("\n".join(summary))
+
+
+class MainWindow(QMainWindow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Luca Learning Companion")
+        self.resize(900, 600)
+
+        self.student_id = "student"
+        self.progress = StudentProgress(student_id=self.student_id, completed_lessons=[], completed_tests=[])
+        self.current_subject: Optional[str] = None
+        self.current_topic: Optional[str] = None
+        self.current_grade: Optional[int] = None
+        self.current_lesson_text = ""
+
+        self.stacked_widget = QStackedWidget()
+        self.setCentralWidget(self.stacked_widget)
+
+        self.intro_page = IntroPage()
+        self.lesson_list_page = LessonListPage()
+        self.lesson_page = LessonPage()
+        self.test_page = TestPage()
+        self.progress_page = ProgressPage()
+
+        self.stacked_widget.addWidget(self.intro_page)
+        self.stacked_widget.addWidget(self.lesson_list_page)
+        self.stacked_widget.addWidget(self.lesson_page)
+        self.stacked_widget.addWidget(self.test_page)
+        self.stacked_widget.addWidget(self.progress_page)
+
+        self.intro_page.started.connect(self._on_intro_started)
+        self.lesson_list_page.lesson_selected.connect(self._open_lesson)
+        self.lesson_list_page.progress_requested.connect(self._show_progress)
+        self.lesson_list_page.launch_game_requested.connect(self._launch_game)
+        self.lesson_page.go_back.connect(self._show_lesson_list)
+        self.lesson_page.start_test.connect(self._start_test)
+        self.test_page.back_requested.connect(self._show_lesson_list)
+        self.test_page.test_completed.connect(self._record_test)
+        self.progress_page.back_requested.connect(self._show_lesson_list)
+
+    # Navigation helpers -------------------------------------------------
+
+    def _on_intro_started(self, student_name: str) -> None:
+        self.student_id = student_name
+        self.progress = load_progress(student_name)
+        self.lesson_list_page._update_subjects()  # Ensure combos refresh
+        self._show_lesson_list()
+
+    def _show_lesson_list(self) -> None:
+        self.stacked_widget.setCurrentWidget(self.lesson_list_page)
+
+    def _show_progress(self) -> None:
+        self.progress_page.display_progress(self.progress)
+        self.stacked_widget.setCurrentWidget(self.progress_page)
+
+    def _open_lesson(self, subject: str, grade: int, topic: str) -> None:
+        self.current_subject = subject
+        self.current_grade = grade
+        self.current_topic = topic
+
+        lesson_text = ai_interface.generate_lesson_sync(subject, grade, topic)
+        self.current_lesson_text = lesson_text
+
+        self.lesson_page.display_lesson(subject, topic, lesson_text)
+        self.stacked_widget.setCurrentWidget(self.lesson_page)
+
+        # Update lesson progress if not already recorded
+        lesson_entry = {
+            "subject": subject,
+            "grade": grade,
+            "topic": topic,
+        }
+        if lesson_entry not in self.progress.completed_lessons:
+            self.progress.completed_lessons.append(lesson_entry)
+            self._persist_progress()
+
+    def _start_test(self) -> None:
+        if not (self.current_subject and self.current_grade and self.current_topic):
+            QMessageBox.information(self, "Pick a lesson first", "Choose a lesson before attempting the quiz.")
+            return
+        exercises = ai_interface.generate_exercises_sync(
+            self.current_subject, self.current_grade, self.current_topic
+        )
+        if not exercises:
+            QMessageBox.warning(self, "No exercises", "We could not load a quiz for this topic right now.")
+            return
+        self.test_page.load_exercises(exercises, self.current_lesson_text)
+        self.stacked_widget.setCurrentWidget(self.test_page)
+
+    def _record_test(self, score: int, total: int) -> None:
+        if not (self.current_subject and self.current_grade and self.current_topic):
+            self._show_lesson_list()
+            return
+        QMessageBox.information(self, "Quiz complete", f"You scored {score} out of {total}.")
+        test_entry = {
+            "subject": self.current_subject,
+            "grade": self.current_grade,
+            "topic": self.current_topic,
+            "score": score,
+            "total": total,
+        }
+        self.progress.completed_tests.append(test_entry)
+        self._persist_progress()
+        self._show_lesson_list()
+
+    def _persist_progress(self) -> None:
+        try:
+            save_progress(self.progress)
+        except Exception as exc:  # pragma: no cover - disk issues
+            LOGGER.error("Failed to save progress: %s", exc)
+
+    def _launch_game(self) -> None:
+        if run_labyrinth_game is None:
+            QMessageBox.information(self, "Game unavailable", "The labyrinth game is not installed.")
+            return
+        try:
+            run_labyrinth_game()
+        except Exception as exc:  # pragma: no cover - runtime issues
+            QMessageBox.warning(self, "Game error", str(exc))
+
+
+def main() -> int:
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run helper
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a PyQt6-based main window with intro, lesson list, lesson, quiz, and progress pages tied together
- integrate asynchronous Gemini API helpers with graceful fallbacks to local content
- persist student progress to disk and include a simple pygame labyrinth mini-game option

## Testing
- python -m py_compile main.py ai_interface.py content_generator.py data_store.py games/labyrinth_game.py

------
https://chatgpt.com/codex/tasks/task_e_68da0592128c8331ba41130cf398de79